### PR TITLE
Create `SimpleButton` and `Button` components

### DIFF
--- a/app/_components/action-list/index.tsx
+++ b/app/_components/action-list/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import Link from "next/link";
+import Button from "@/_components/button";
 import styles from "./styles.module.css";
 import { useEffect, useRef, useState } from "react";
 
@@ -53,7 +53,7 @@ export default function ActionList({ actions, align = "left" }: { actions: Actio
             <ul className={styles.list} data-align={align}>
                 {actions.map(action => (
                     <li key={action.label}>
-                        <Link
+                        <Button
                             href={action.href}
                             data-primary={action.primary}
                             ref={action.primary ? primaryActionRef : undefined}
@@ -63,7 +63,7 @@ export default function ActionList({ actions, align = "left" }: { actions: Actio
                             onBlur={_ => isHoverWanted.matches && setHighlightedAction(primaryActionRef.current)}
                         >
                             {action.label}
-                        </Link>
+                        </Button>
                     </li>
                 ))}
             </ul>

--- a/app/_components/action-list/styles.module.css
+++ b/app/_components/action-list/styles.module.css
@@ -8,19 +8,19 @@
         font-weight: inherit;
 
         &[data-primary="true"] {
-        font-weight: bold;
-    }
+            font-weight: bold;
+        }
 
         &:not([data-primary="true"]) {
-        text-decoration: underline wavy currentColor 0.05em;
+            text-decoration: underline wavy currentColor 0.05em;
 
             &::before {
-        content: "or";
-        display: inline-block;
-        text-decoration: none;
-        margin-inline-end: 0.3em;
-    }
-}
+                content: "or";
+                display: inline-block;
+                text-decoration: none;
+                margin-inline-end: 0.3em;
+            }
+        }
     }
 }
 

--- a/app/_components/action-list/styles.module.css
+++ b/app/_components/action-list/styles.module.css
@@ -2,26 +2,25 @@
     list-style: none;
     width: fit-content;
 
-    & > a {
-        display: inline-block;
-        padding: 0.9rem 1.8rem;
-        text-decoration: none;
+    & > * {
+        background: transparent;
         color: inherit;
-    }
+        font-weight: inherit;
 
-    & > a[data-primary="true"] {
+        &[data-primary="true"] {
         font-weight: bold;
     }
 
-    & > a:not([data-primary="true"]) {
+        &:not([data-primary="true"]) {
         text-decoration: underline wavy currentColor 0.05em;
-    }
 
-    & > a:not([data-primary="true"])::before {
+            &::before {
         content: "or";
         display: inline-block;
         text-decoration: none;
         margin-inline-end: 0.3em;
+    }
+}
     }
 }
 

--- a/app/_components/button/index.tsx
+++ b/app/_components/button/index.tsx
@@ -1,0 +1,38 @@
+import { ReactNode } from "react";
+import styles from "./styles.module.css";
+import Link from "next/link";
+import SimpleButton from "../simple-button";
+
+type WidthPreference = "min" | "hug" | "fill";
+type HeightPreference = "min" | "hug" | "fill";
+type DensityPreference = "compact" | "default";
+
+export default function Button({
+    href,
+    className = "",
+    width = "hug",
+    height = "hug",
+    density = "default",
+    children,
+    ...attributes
+}: {
+    href?: string;
+    className?: string;
+    width?: WidthPreference;
+    height?: HeightPreference;
+    density?: DensityPreference;
+    children?: ReactNode | ReactNode[];
+    [attribute: string]: any;
+}) {
+    return (
+        <SimpleButton
+            className={`${styles.button} ${className}`}
+            data-width={width}
+            data-height={height}
+            data-density={density}
+            href={href}
+            children={children}
+            {...attributes}
+        />
+    );
+}

--- a/app/_components/button/styles.module.css
+++ b/app/_components/button/styles.module.css
@@ -1,0 +1,45 @@
+.button {
+    background: var(--color-on-background);
+    color: var(--color-background);
+    /* font-weight: 600; */
+
+    transition: scale var(--motion-duration-short2) var(--motion-easing-emphasized);
+
+    &:active {
+        scale: 0.98;
+    }
+
+    /* Variants */
+
+    &[data-width="min"] {
+        width: min-content;
+    }
+
+    &[data-width="hug"] {
+        width: fit-content;
+    }
+
+    &[data-width="fill"] {
+        width: 100%;
+    }
+
+    &[data-height="min"] {
+        padding-block: 0.65rem;
+    }
+
+    &[data-height="hug"] {
+        padding-block: 0.9rem;
+    }
+
+    &[data-height="fill"] {
+        height: 100%;
+    }
+
+    &[data-density="default"] {
+        padding-inline: 1.4rem;
+    }
+
+    &[data-density="compact"] {
+        padding-inline: 1rem;
+    }
+}

--- a/app/_components/simple-button/index.tsx
+++ b/app/_components/simple-button/index.tsx
@@ -1,0 +1,25 @@
+import { ReactNode } from "react";
+import styles from "./styles.module.css";
+import Link from "next/link";
+
+export default function SimpleButton({
+    href,
+    className = "",
+    children,
+    ...attributes
+}: {
+    href?: string;
+    className?: string;
+    children?: ReactNode | ReactNode[];
+    [attribute: string]: any;
+}) {
+    return href ? (
+        <Link className={`${styles.button} ${className}`} href={href} {...attributes}>
+            {children}
+        </Link>
+    ) : (
+        <button className={`${styles.button} ${className}`} {...attributes}>
+            {children}
+        </button>
+    );
+}

--- a/app/_components/simple-button/styles.module.css
+++ b/app/_components/simple-button/styles.module.css
@@ -1,0 +1,23 @@
+.button {
+    all: unset;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    background: transparent;
+    color: inherit;
+    text-align: center;
+    border-radius: 100vh;
+
+    pointer-events: all;
+    cursor: pointer;
+
+    padding: 2px;
+    box-sizing: border-box;
+
+    &:focus-visible {
+        outline: 2px solid var(--color-tertiary);
+        outline-offset: 2px;
+    }
+}


### PR DESCRIPTION
Create `SimpleButton` and `Button` components, as part of work on #13.

## `SimpleButton` (`app/_components/simple-button`)

A bare bones wrapper for `<button>` or `<Link>` that removes all the default styling to apply consistent ones across both variants. This component serves as the base for `Button`.

**Usage:**
```tsx
SimpleButton({
    href?: string,
    children?: ReactNode | ReactNode[],
    [attribute: string]: any
}): JSX.Element
```

**Description:**
- Takes in an optional `href` prop
  - If `href` is specified, this component is a wrapper for `<Link>`
  - Otherwise, it renders as `<button>`
- Passes any other specified prop to the underlying element
- Removes default styles and applies a consistent styling across both variants
  - Outline:
    ![Outline of SimpleButton](https://github.com/user-attachments/assets/7f7ad1dc-91b6-4aa4-bbce-2baccdc95b38)
- Handles styling on `:focus-visible`

## `Button` (`app/_components/button`)

An extension of `SimpleButton` that is styled more like a so-perceived "button".

**Usage:**
```tsx
Button({
    href?: string,
    width?: "min" | "hug" | "fill",
    height?: "min" | "hug" | "fill",
    density?: "compact" | "default",
    children?: ReactNode | ReactNode[],
    [attribute: string]: any,
}): JSX.Element
```

**Description:**
- Styles with app-themes background and text color
  - Outline:
    ![Outline of Button](https://github.com/user-attachments/assets/fc843550-59c1-4945-b766-e8af1a1e29c3)
- Offers customization through props: `width`, `height`, `density`
- Provides visual feedback on `:active`
