### PR TITLE
Create `TextInput` component

### DIFF
--- a/app/_components/text-input/index.tsx
+++ b/app/_components/text-input/index.tsx
@@ -1,0 +1,19 @@
+import styles from "./styles.module.css";
+
+type TextTypes = "text" | "number" | "email" | "password" | "search" | "tel" | "url";
+
+export default function TextInput({
+    type = "text",
+    placeholder = "",
+    className = "",
+    ...attributes
+}: {
+    type?: TextTypes;
+    placeholder?: string;
+    className?: string;
+    [attribute: string]: any;
+}) {
+    return (
+        <input className={`${styles.input} ${className ?? ""}`} type={type} placeholder={placeholder} {...attributes} />
+    );
+}

--- a/app/_components/text-input/styles.module.css
+++ b/app/_components/text-input/styles.module.css
@@ -1,0 +1,25 @@
+.input {
+    all: unset;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    background: transparent;
+    color: inherit;
+    border: 1px solid var(--color-outline);
+    border-radius: 12px;
+
+    pointer-events: all;
+    cursor: text;
+
+    width: 100%;
+    padding-block: 0.9rem;
+    padding-inline: 1rem 0.5rem;
+    box-sizing: border-box;
+
+    &:focus-visible {
+        outline: 2px solid var(--color-tertiary);
+        outline-offset: -2px;
+    }
+}


### PR DESCRIPTION
Added a new `TextInput` component (`app/_components/text-input`). Part of work on #12.
- Wrapper for `<input>` that serves as a replacement for most of its "text" `type` variants (`text`, `email`, `password`, etc.).
- Takes `type` and `placeholder` props, passes rest to the underlying `<input>` element.
- Outline:
  ![Outline of TextInput](https://github.com/user-attachments/assets/de0b29c4-755d-440e-b7eb-70144e81273f)