### PR TITLE
Fix #16: Focusing on "or explore first!" doesn't move the background to it

### DIFF
--- a/app/_components/action-list/index.tsx
+++ b/app/_components/action-list/index.tsx
@@ -59,8 +59,8 @@ export default function ActionList({ actions, align = "left" }: { actions: Actio
                             ref={action.primary ? primaryActionRef : undefined}
                             onMouseEnter={e => isHoverWanted.matches && setHighlightedAction(e.currentTarget)}
                             onMouseLeave={_ => isHoverWanted.matches && setHighlightedAction(primaryActionRef.current)}
-                            onFocus={e => isHoverWanted.matches && setHighlightedAction(e.currentTarget)}
-                            onBlur={_ => isHoverWanted.matches && setHighlightedAction(primaryActionRef.current)}
+                            onFocus={e => setHighlightedAction(e.currentTarget)}
+                            onBlur={_ => setHighlightedAction(primaryActionRef.current)}
                         >
                             {action.label}
                         </Button>


### PR DESCRIPTION
Removed the conditional check for `isHoverWanted.matches` in `onFocus` & `onBlur` event handlers.

```diff
-    onFocus={e => isHoverWanted.matches && setHighlightedAction(e.currentTarget)}
-    onBlur={_ => isHoverWanted.matches && setHighlightedAction(primaryActionRef.current)}
+    onFocus={e => setHighlightedAction(e.currentTarget)}
+    onBlur={_ => setHighlightedAction(primaryActionRef.current)}
```

Fixes #16.