### PR TITLE
Hotfixes for minor issues with `Button` component

### DIFF
--- a/app/_components/action-list/styles.module.css
+++ b/app/_components/action-list/styles.module.css
@@ -12,7 +12,7 @@
         }
 
         &:not([data-primary="true"]) {
-            text-decoration: underline wavy currentColor 0.05em;
+            /* text-decoration: underline wavy currentColor 0.05em; */
 
             &::before {
                 content: "or";

--- a/app/_components/button/index.tsx
+++ b/app/_components/button/index.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from "react";
 import styles from "./styles.module.css";
-import Link from "next/link";
 import SimpleButton from "../simple-button";
 
 type WidthPreference = "min" | "hug" | "fill";

--- a/app/_components/simple-button/styles.module.css
+++ b/app/_components/simple-button/styles.module.css
@@ -1,4 +1,5 @@
-.button {
+/* Lower specificity of SimpleButton's styles */
+:where(.button) {
     all: unset;
 
     display: inline-flex;


### PR DESCRIPTION
This pull request provides hotfixes for two issues caused by the implementation and usage of `Button`.

## 1. "or" is underlined in `ActionList`

- **Issue:** Prefix ("or") of non-primary items in `ActionList` is underlined. It isn't supposed to be.
  ![image](https://github.com/user-attachments/assets/c6be43b9-4882-4f10-909c-a9715b90ad39)
- **Hotfix:** Remove underline from the prefix.

## 2. `SimpleButton`'s styles override `Button`'s styles

- **Issue:** When both `SimpleButton` and `Button` are used in page, `SimpleButton`'s styles take precedence over `Button`'s styles
  ![image](https://github.com/user-attachments/assets/59a83968-41f3-4f19-b5ef-4ea5edfc36bb)
- **Hotfix:** Lower specificity of `SimpleButton`'s styles using the `:where` selector
- **Possible solutions:** Use CSS cascade layers