### PR TITLE
Create `/auth` and `/auth/login` pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+MONGODB_URI=mongodburi

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 MONGODB_URI=mongodburi
+JWT_SECRET=jwtsecret

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/api/v1/get-user-details/route.ts
+++ b/app/api/v1/get-user-details/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { connectDB } from "@/lib/mongodb";
+import { User } from "@/models/User";
+
+export async function GET(request: NextRequest) {
+    try {
+        const email = request.nextUrl.searchParams.get("email");
+        if (!email) return NextResponse.json({ error: "Email not provided" }, { status: 400 });
+
+        await connectDB();
+
+        const user = await User.findOne({ email }).select("name email accountActivated");
+        if (!user) return NextResponse.json({ error: "User not found" }, { status: 404 });
+
+        return NextResponse.json({
+            name: user.name,
+            email: user.email,
+            accountActivated: user.accountActivated,
+        });
+    } catch (error) {
+        console.error("Error in v1/get-user-details:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/app/api/v1/login/route.ts
+++ b/app/api/v1/login/route.ts
@@ -1,0 +1,39 @@
+import bcrypt from "bcryptjs";
+import { SignJWT } from "jose";
+import { NextResponse } from "next/server";
+import { connectDB } from "@/lib/mongodb";
+import { User } from "@/models/User";
+
+export async function POST(request: Request) {
+    try {
+        const { email, password } = await request.json();
+        if (!email) return NextResponse.json({ error: "Email not provided" }, { status: 400 });
+        if (!password) return NextResponse.json({ error: "Password not provided" }, { status: 400 });
+
+        await connectDB();
+
+        const user = await User.findOne({ email });
+        if (!user) return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+
+        const isPasswordValid = await bcrypt.compare(password, user.password);
+        if (!isPasswordValid) return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+
+        const secret = new TextEncoder().encode(process.env.JWT_SECRET);
+        const token = await new SignJWT({ userId: user._id })
+            .setProtectedHeader({ alg: "HS256" })
+            .setExpirationTime("4w")
+            .setIssuedAt()
+            .sign(secret);
+
+        return NextResponse.json({
+            token,
+            user: {
+                name: user.name,
+                email: user.email,
+            },
+        });
+    } catch (error) {
+        console.error("Error in v1/login:", error);
+        return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+    }
+}

--- a/app/auth/login/page.module.css
+++ b/app/auth/login/page.module.css
@@ -1,0 +1,50 @@
+.app {
+    min-height: 100dvh;
+    background: linear-gradient(#d1b9ff, #f2eefa 30%);
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    height: 64px;
+    padding: 0 16px;
+}
+
+.main {
+    padding: 0 32px;
+
+    & > h1 {
+        margin-block: 4rem;
+        font-size: 2em;
+        font-weight: 600;
+        text-align: center;
+    }
+
+    & > form {
+        font-size: 1.25em;
+        display: flex;
+        flex-direction: column;
+        gap: 0.8em;
+
+        & .fields {
+            display: flex;
+            flex-direction: column;
+            gap: 0.6em;
+        }
+    }
+}
+
+.forgotPassword {
+    font-size: 0.8em;
+    color: var(--color-on-secondary-container);
+    float: right;
+}
+
+.error {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+
+    color: var(--color-error);
+    margin-block-start: 0.4em;
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import "@material-design-icons/font/outlined.css";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState, useEffect } from "react";
+import Button from "@/_components/button";
+import SimpleButton from "@/_components/simple-button";
+import TextInput from "@/_components/text-input";
+import styles from "./page.module.css";
+
+export default function Login() {
+    const router = useRouter();
+
+    const searchParams = useSearchParams();
+    const [email, setEmail] = useState(searchParams.get("email") ?? "");
+
+    const [password, setPassword] = useState("");
+    const [error, setError] = useState("");
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError("");
+
+        await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/login`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ email, password }),
+        })
+            .then(async response => {
+                const data = await response.json();
+                if (!response.ok) throw new Error(data.error);
+
+                // Redirect to dashboard
+                router.push("/dashboard");
+            })
+            .catch(err => {
+                setError(err.message ?? "An error occurred");
+            });
+    };
+
+    return (
+        <div className={styles.app}>
+            <nav className={styles.nav}>
+                <SimpleButton onClick={() => window.history.back()}>
+                    <span className="material-icons-outlined">chevron_left</span>
+                    Back
+                </SimpleButton>
+            </nav>
+            <main className={styles.main}>
+                <h1>Login</h1>
+                <form onSubmit={handleSubmit}>
+                    <div className={styles.fields}>
+                        <TextInput
+                            type="text"
+                            placeholder="Enter your email"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                            required
+                        />
+                        <div>
+                            <TextInput
+                                type="password"
+                                placeholder="Enter password"
+                                value={password}
+                                onChange={e => setPassword(e.target.value)}
+                                required
+                                autoFocus
+                            />
+                            <SimpleButton className={styles.forgotPassword}>Forgot password?</SimpleButton>
+                        </div>
+                        {error && (
+                            <p className={styles.error}>
+                                <span className="material-icons-outlined">error</span>
+                                {error}
+                            </p>
+                        )}
+                    </div>
+                    <Button type="submit" width="fill">
+                        Login
+                    </Button>
+                </form>
+            </main>
+        </div>
+    );
+}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -14,8 +14,35 @@ export default function Login() {
     const searchParams = useSearchParams();
     const [email, setEmail] = useState(searchParams.get("email") ?? "");
 
+    const [firstName, setFirstName] = useState("");
     const [password, setPassword] = useState("");
     const [error, setError] = useState("");
+
+    // Fetch/update first name on email change
+    useEffect(() => {
+        if (!email) {
+            setFirstName("");
+            return;
+        }
+
+        const controller = new AbortController();
+        const signal = controller.signal;
+
+        fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/get-user-details?email=${encodeURIComponent(email)}`, {
+            signal,
+        })
+            .then(async response => {
+                const data = await response.json();
+                if (!response.ok) throw new Error(data.error);
+
+                setFirstName(data.name.split(" ")[0]);
+            })
+            .catch(_ => {
+                setFirstName("");
+            });
+
+        return () => controller.abort();
+    }, [email]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -49,7 +76,7 @@ export default function Login() {
                 </SimpleButton>
             </nav>
             <main className={styles.main}>
-                <h1>Login</h1>
+                <h1>{firstName ? `Is it you, ${firstName}?` : "Login"}</h1>
                 <form onSubmit={handleSubmit}>
                     <div className={styles.fields}>
                         <TextInput

--- a/app/auth/page.module.css
+++ b/app/auth/page.module.css
@@ -1,0 +1,29 @@
+.app {
+    min-height: 100dvh;
+    background: linear-gradient(#d1b9ff, #f2eefa 30%);
+}
+
+.nav {
+    display: flex;
+    align-items: center;
+    height: 64px;
+    padding: 0 16px;
+}
+
+.main {
+    padding: 0 32px;
+
+    & > h1 {
+        margin-block: 4rem;
+        font-size: 2em;
+        font-weight: 600;
+        text-align: center;
+    }
+
+    & > form {
+        font-size: 1.25em;
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+    }
+}

--- a/app/auth/page.module.css
+++ b/app/auth/page.module.css
@@ -27,3 +27,12 @@
         gap: 1.25rem;
     }
 }
+
+.error {
+    display: flex;
+    align-items: center;
+    gap: 0.25em;
+
+    color: var(--color-error);
+    margin-block-start: 0.4em;
+}

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@material-design-icons/font/outlined.css";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import Button from "@/_components/button";
 import SimpleButton from "@/_components/simple-button";
@@ -9,9 +9,31 @@ import TextInput from "@/_components/text-input";
 import styles from "./page.module.css";
 
 export default function Auth() {
+    const router = useRouter();
+
     const searchParams = useSearchParams();
     const [email, setEmail] = useState(searchParams.get("email") || "");
+
     const [error, setError] = useState("");
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        setError("");
+
+        await fetch(`${process.env.NEXT_PUBLIC_API_BASE_URL}/get-user-details?email=${encodeURIComponent(email)}`)
+            .then(async response => {
+                const data = await response.json();
+
+                if (!response.ok) throw new Error(data.error);
+
+                if (data.accountCreated) router.push(`/auth/login?email=${encodeURIComponent(email)}`);
+                else router.push(`/auth/register?email=${encodeURIComponent(email)}`);
+            })
+            .catch(err => {
+                setError(err.message ?? "An error occurred");
+            });
+    };
 
     return (
         <div className={styles.app}>
@@ -23,6 +45,7 @@ export default function Auth() {
             </nav>
             <main className={styles.main}>
                 <h1>Login or Register</h1>
+                <form onSubmit={handleSubmit}>
                     <div>
                         <TextInput
                             type="text"

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import "@material-design-icons/font/outlined.css";
+import { useSearchParams } from "next/navigation";
+import { useState } from "react";
+import Button from "@/_components/button";
+import SimpleButton from "@/_components/simple-button";
+import TextInput from "@/_components/text-input";
+import styles from "./page.module.css";
+
+export default function Auth() {
+    const searchParams = useSearchParams();
+    const [email, setEmail] = useState(searchParams.get("email") || "");
+
+    return (
+        <div className={styles.app}>
+            <nav className={styles.nav}>
+                <SimpleButton onClick={() => window.history.back()}>
+                    <span className="material-icons-outlined">chevron_left</span>
+                    Back
+                </SimpleButton>
+            </nav>
+            <main className={styles.main}>
+                <h1>Login or Register</h1>
+                <form>
+                    <TextInput
+                        type="text"
+                        placeholder="Enter your email"
+                        value={email}
+                        onChange={e => setEmail(e.target.value)}
+                        autoFocus
+                    />
+                    <Button type="submit" width="fill">
+                        Continue
+                    </Button>
+                </form>
+            </main>
+        </div>
+    );
+}

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -11,6 +11,7 @@ import styles from "./page.module.css";
 export default function Auth() {
     const searchParams = useSearchParams();
     const [email, setEmail] = useState(searchParams.get("email") || "");
+    const [error, setError] = useState("");
 
     return (
         <div className={styles.app}>
@@ -22,14 +23,21 @@ export default function Auth() {
             </nav>
             <main className={styles.main}>
                 <h1>Login or Register</h1>
-                <form>
-                    <TextInput
-                        type="text"
-                        placeholder="Enter your email"
-                        value={email}
-                        onChange={e => setEmail(e.target.value)}
-                        autoFocus
-                    />
+                    <div>
+                        <TextInput
+                            type="text"
+                            placeholder="Enter your email"
+                            value={email}
+                            onChange={e => setEmail(e.target.value)}
+                            autoFocus
+                        />
+                        {error && (
+                            <p className={styles.error}>
+                                <span className="material-icons-outlined">error</span>
+                                {error}
+                            </p>
+                        )}
+                    </div>
                     <Button type="submit" width="fill">
                         Continue
                     </Button>

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -27,7 +27,7 @@ export default function Auth() {
 
                 if (!response.ok) throw new Error(data.error);
 
-                if (data.accountCreated) router.push(`/auth/login?email=${encodeURIComponent(email)}`);
+                if (data.accountActivated) router.push(`/auth/login?email=${encodeURIComponent(email)}`);
                 else router.push(`/auth/register?email=${encodeURIComponent(email)}`);
             })
             .catch(err => {
@@ -52,6 +52,7 @@ export default function Auth() {
                             placeholder="Enter your email"
                             value={email}
                             onChange={e => setEmail(e.target.value)}
+                            required
                             autoFocus
                         />
                         {error && (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,6 +22,7 @@ export const metadata: Metadata = {
 
 export const viewport: Viewport = {
     themeColor: "#ab8aed",
+    interactiveWidget: "resizes-content",
 };
 
 export default function RootLayout({

--- a/app/lib/mongodb.ts
+++ b/app/lib/mongodb.ts
@@ -1,0 +1,11 @@
+import mongoose from "mongoose";
+
+export async function connectDB() {
+    try {
+        if (mongoose.connection.readyState === 1) return;
+
+        await mongoose.connect(process.env.MONGODB_URI!);
+    } catch (error) {
+        console.error("MongoDB connection error:", error);
+    }
+}

--- a/app/models/User.ts
+++ b/app/models/User.ts
@@ -1,0 +1,15 @@
+import mongoose from "mongoose";
+
+const userSchema = new mongoose.Schema({
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    password: {
+        type: String,
+        required: function (this: any) {
+            return this.accountActivated === true;
+        },
+    },
+    accountActivated: { type: Boolean, default: false },
+});
+
+export const User = mongoose.models.User || mongoose.model("User", userSchema);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+// "use client";
 
 import Image from "next/image";
 import ActionList from "@/_components/action-list";
@@ -26,7 +26,7 @@ export default function Home() {
                     actions={[
                         {
                             label: "Get Started",
-                            href: "/login",
+                            href: "/auth",
                             primary: true,
                         },
                         {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "lint": "next lint"
     },
     "dependencies": {
+        "@material-design-icons/font": "^0.14.15",
         "@splidejs/react-splide": "^0.7.12",
         "bcryptjs": "^3.0.2",
         "jose": "^6.0.10",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     },
     "dependencies": {
         "@splidejs/react-splide": "^0.7.12",
+        "mongoose": "^8.13.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "next": "15.2.2"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     },
     "dependencies": {
         "@splidejs/react-splide": "^0.7.12",
+        "bcryptjs": "^3.0.2",
+        "jose": "^6.0.10",
         "mongoose": "^8.13.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",


### PR DESCRIPTION
This pull request presents two new fully functional pages:
1. `/auth` (closes #2), and 
2. `/auth/login` (closes #14)

Both pages are as per the discussed specifications with quality of life features added for the most part.
Input validation remains as a future task for @Techkulkul. 

**Additional changes of note:**
- Set `interactive-widget` meta property to `resizes-content` as default for all pages
- New dependency: `@material-design-icons/font`